### PR TITLE
B09 - 최초 로그인 시 유저 name 저장하지 않도록 수정

### DIFF
--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -18,7 +18,7 @@ export class AuthService {
       throw new UnauthorizedException('인증 오류');
     }
 
-    const { email, name, profileImageUrl } = req.user;
+    const { email, profileImageUrl } = req.user;
 
     const exist = await this.usersRepository.findOne({
       where: { email, deletedAt: null },
@@ -31,7 +31,6 @@ export class AuthService {
       await this.usersRepository.save({
         provider: provider,
         email,
-        name,
         profileImageUrl,
       });
     }

--- a/backend/src/auth/passport/facebook.strategy.ts
+++ b/backend/src/auth/passport/facebook.strategy.ts
@@ -9,7 +9,7 @@ export class FacebookStrategy extends PassportStrategy(Strategy, 'facebook') {
       clientID: process.env.FACEBOOK_CLIENT_ID,
       clientSecret: process.env.FACEBOOK_SECRET,
       callbackURL: `http://localhost:${process.env.PORT}/api/auth/facebook/callback`,
-      profileFields: ['emails', 'name', 'photos'],
+      profileFields: ['emails', 'photos'],
     });
   }
 
@@ -19,10 +19,9 @@ export class FacebookStrategy extends PassportStrategy(Strategy, 'facebook') {
     profile: any,
     done: VerifyCallback,
   ): Promise<any> {
-    const { name, emails, photos } = profile;
+    const { emails, photos } = profile;
     const user = {
       email: emails[0].value,
-      name: `${name.givenName} ${name.familyName}`,
       profileImageUrl: photos[0].value,
       accessToken,
     };

--- a/backend/src/auth/passport/github.strategy.ts
+++ b/backend/src/auth/passport/github.strategy.ts
@@ -18,10 +18,9 @@ export class GithubStrategy extends PassportStrategy(Strategy, 'github') {
     profile: any,
     done: VerifyCallback,
   ): Promise<any> {
-    const { displayName, emails, photos } = profile;
+    const { emails, photos } = profile;
     const user = {
       email: emails[0].value,
-      name: displayName,
       profileImageUrl: photos[0].value,
       accessToken,
     };

--- a/backend/src/auth/passport/google.strategy.ts
+++ b/backend/src/auth/passport/google.strategy.ts
@@ -19,10 +19,9 @@ export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
     profile: any,
     done: VerifyCallback,
   ): Promise<any> {
-    const { name, emails, photos } = profile;
+    const { emails, photos } = profile;
     const user = {
       email: emails[0].value,
-      name: `${name.givenName} ${name.familyName}`,
       profileImageUrl: photos[0].value,
       accessToken,
     };

--- a/backend/src/users/users.entity.ts
+++ b/backend/src/users/users.entity.ts
@@ -42,7 +42,6 @@ export class User extends BaseEntity {
     description: '이름(닉네임)',
     example: '심바',
   })
-  @IsNotEmpty()
   @IsString()
   @Column({ default: null })
   name: string | null;


### PR DESCRIPTION
Close #3 

### 작업 내용
- 유저 entity에서 name 컬럼의 IsNotEmpty 데코레이터 삭제
- 소셜 로그인 strategy에서 이름 받아오는 부분 삭제
- 최초 로그인 시 유저 name 저장하지 않도록 서비스 로직 수정